### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
   - 0.3
   - 0.4
+  - 0.5
   - nightly
 matrix:
   allow_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,5 +3,3 @@ BinDeps
 Compat
 Images
 Colors
-FactCheck
-TestImages

--- a/src/VLFeat.jl
+++ b/src/VLFeat.jl
@@ -3,7 +3,7 @@ using Images
 using Colors
 using BinDeps
 
-depsfile = Pkg.dir("VLFeat","deps","deps.jl")
+depsfile = joinpath(dirname(@__FILE__),"..","deps","deps.jl")
 if isfile(depsfile)
     include(depsfile)
 else

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,3 @@
 ImageMagick
+TestImages
+FactCheck


### PR DESCRIPTION
so that the package can be installed elsewhere

Add testing against 0.5 to Travis
this runs the most recent release candidate now, release once final tags are done

move FactCheck and TestImages from REQUIRE to test/REQUIRE
since they are test-only dependencies
